### PR TITLE
Develop

### DIFF
--- a/compat/trivial-shell.lisp
+++ b/compat/trivial-shell.lisp
@@ -84,34 +84,42 @@ The input is read from the :input key argument.
       (format *trace-output* "~&; ~a '~a'" *interpreter* command))
     (with-process (p argv)
       ;; input
-      (when input
-        (let ((max-retry 100) (failcnt 0))
-          (tagbody
-            :start
-            (handler-case
-                (with-open-file (s (fd-as-pathname p 0)
-                                   :direction :output
-                                   :if-exists :overwrite)
-                  (etypecase input
-                    (stream
-                     (handler-case
-                         (loop (write-char (read-char input) s))
-                       (end-of-file (c)
-                         (declare (ignore c)))))
-                    (sequence
-                     (write-sequence input s))))
-              (file-error (c)
-                (sleep 0.01)
-                (incf failcnt)
-                (if (< failcnt max-retry)
-                    (go :start)
-                    (signal c)))))))
-      ;; this is necessary since the lisp process may still open the fd
-      (iolib.syscalls:close (fd p 0))
-      ;; now, read the output
-      (with-open-file (s1 (fd-as-pathname p 1) :external-format external-format)
-        (with-open-file (s2 (fd-as-pathname p 2) :external-format external-format)
-          (loop-impl4 p s1 s2))))))
+      (macrolet ((with-retry-open-file ((max tag) args &body body)
+                   (with-gensyms (maxcnt failcnt condition)
+                     `(let ((,maxcnt ,max)
+                            (,failcnt 0))
+                        (tagbody
+                          ,tag
+                          (handler-case
+                              (with-open-file ,args
+                                ,@body)
+                            (file-error (,condition)
+                              (sleep 0.01)
+                              (incf ,failcnt)
+                              (if (< ,failcnt ,maxcnt)
+                                  (go ,tag)
+                                  (signal ,condition)))))))))
+        (when input
+          (with-retry-open-file (100 :start) 
+            (s (fd-as-pathname p 0)
+               :direction :output
+               :if-exists :overwrite)
+            (etypecase input
+              (stream
+               (handler-case
+                   (loop (write-char (read-char input) s))
+                 (end-of-file (c)
+                   (declare (ignore c)))))
+              (sequence
+               (write-sequence input s)))))
+        ;; this is necessary since the lisp process may still open the fd
+        (iolib.syscalls:close (fd p 0))
+        ;; now, read the output
+        (with-retry-open-file (100 :start1)
+          (s1 (fd-as-pathname p 1) :external-format external-format)
+          (with-retry-open-file (100 :start2)
+            (s2 (fd-as-pathname p 2) :external-format external-format)
+            (loop-impl4 p s1 s2)))))))
 
 (defun loop-impl2 (p s1 s2)
   "busy-waiting. works but inefficient"

--- a/compat/trivial-shell.lisp
+++ b/compat/trivial-shell.lisp
@@ -118,11 +118,15 @@ The input is read from the :input key argument.
       ;; this is necessary since the lisp process may still open the fd
       (iolib.syscalls:close (fd p 0))
       ;; now, read the output
-      (with-retry-open-file (100 :start1)
-        (s1 (fd-as-pathname p 1) :external-format external-format)
-        (with-retry-open-file (100 :start2)
-          (s2 (fd-as-pathname p 2) :external-format external-format)
-          (loop-impl4 p s1 s2))))))
+      (multiple-value-bind (out err status)
+          (with-retry-open-file (100 :start1)
+            (s1 (fd-as-pathname p 1) :external-format external-format)
+            (with-retry-open-file (100 :start2)
+              (s2 (fd-as-pathname p 2) :external-format external-format)
+              (loop-impl4 p s1 s2)))
+        (values (coerce out 'string)
+                (coerce err 'string)
+                status)))))
 
 (defun loop-impl2 (p s1 s2)
   "busy-waiting. works but inefficient"
@@ -187,7 +191,5 @@ The input is read from the :input key argument.
                 (in outer (collect c result-type string into err)))
                (_ (leave))))
        (leave
-        (values (coerce out 'string)
-                (coerce err 'string)
-                exitstatus))))))
+        (values out err exitstatus))))))
 

--- a/compat/trivial-shell.lisp
+++ b/compat/trivial-shell.lisp
@@ -58,6 +58,24 @@ variable.
           (peek-char nil s nil nil))
         (collect (read-char s nil nil) result-type string)))
 
+(defmacro with-retry-open-file ((max tag) args &body body)
+  (with-gensyms (maxcnt failcnt condition blk)
+    `(block ,blk
+       (let ((,maxcnt ,max)
+             (,failcnt 0))
+         (tagbody
+           ,tag
+           (handler-case
+               (return-from ,blk
+                 (with-open-file ,args
+                   ,@body))
+             (file-error (,condition)
+               (sleep 0.01)
+               (incf ,failcnt)
+               (if (< ,failcnt ,maxcnt)
+                   (go ,tag)
+                   (signal ,condition)))))))))
+
 (declaim (ftype (function ((or pathname string)
                            &key
                            (:input (or stream string null))
@@ -84,44 +102,27 @@ The input is read from the :input key argument.
       (format *trace-output* "~&; ~a '~a'" *interpreter* command))
     (with-process (p argv)
       ;; input
-      (macrolet ((with-retry-open-file ((max tag) args &body body)
-                   (with-gensyms (maxcnt failcnt condition blk)
-                     `(block ,blk
-                        (let ((,maxcnt ,max)
-                              (,failcnt 0))
-                          (tagbody
-                            ,tag
-                            (handler-case
-                                (return-from ,blk
-                                  (with-open-file ,args
-                                    ,@body))
-                              (file-error (,condition)
-                                (sleep 0.01)
-                                (incf ,failcnt)
-                                (if (< ,failcnt ,maxcnt)
-                                    (go ,tag)
-                                    (signal ,condition))))))))))
-        (when input
-          (with-retry-open-file (100 :start) 
-            (s (fd-as-pathname p 0)
-               :direction :output
-               :if-exists :overwrite)
-            (etypecase input
-              (stream
-               (handler-case
-                   (loop (write-char (read-char input) s))
-                 (end-of-file (c)
-                   (declare (ignore c)))))
-              (sequence
-               (write-sequence input s)))))
-        ;; this is necessary since the lisp process may still open the fd
-        (iolib.syscalls:close (fd p 0))
-        ;; now, read the output
-        (with-retry-open-file (100 :start1)
-          (s1 (fd-as-pathname p 1) :external-format external-format)
-          (with-retry-open-file (100 :start2)
-            (s2 (fd-as-pathname p 2) :external-format external-format)
-            (loop-impl4 p s1 s2)))))))
+      (when input
+        (with-retry-open-file (100 :start) 
+          (s (fd-as-pathname p 0)
+             :direction :output
+             :if-exists :overwrite)
+          (etypecase input
+            (stream
+             (handler-case
+                 (loop (write-char (read-char input) s))
+               (end-of-file (c)
+                 (declare (ignore c)))))
+            (sequence
+             (write-sequence input s)))))
+      ;; this is necessary since the lisp process may still open the fd
+      (iolib.syscalls:close (fd p 0))
+      ;; now, read the output
+      (with-retry-open-file (100 :start1)
+        (s1 (fd-as-pathname p 1) :external-format external-format)
+        (with-retry-open-file (100 :start2)
+          (s2 (fd-as-pathname p 2) :external-format external-format)
+          (loop-impl4 p s1 s2))))))
 
 (defun loop-impl2 (p s1 s2)
   "busy-waiting. works but inefficient"

--- a/src/process.lisp
+++ b/src/process.lisp
@@ -63,15 +63,15 @@ then with SIGKILL."
   "option is one of :nohang, :untraced, :continued.
 Returns a value of the following signature:
 
- (vector (boolean ifexited)
-         (integer exitstatus)
-         (boolean ifsignalled)
-         (integer termsig)
-         (boolean coredump)
-         (boolean ifstopped)
-         (integer stopsig)
-         (boolean ifcontinued)
-         (integer status)).
+ (list (boolean ifexited)
+       (integer exitstatus)
+       (boolean ifsignalled)
+       (integer termsig)
+       (boolean coredump)
+       (boolean ifstopped)
+       (integer stopsig)
+       (boolean ifcontinued)
+       (integer status)).
 
 When the value is inappropriate as defined in man wait(2),
 some integer values may return NIL.


### PR DESCRIPTION
several bugfix regarding trivial-shell compat:
- it sometimes returned NIL instead of empty strings : coerce later
- try opening the output several times
- supply the input only when the input is given

fixes are to some extent ad-hoc, but working well on the practical application on the cluster
